### PR TITLE
docs: document the recipe property and clarify the env title

### DIFF
--- a/src/main/java/io/kestra/plugin/datahub/Ingestion.java
+++ b/src/main/java/io/kestra/plugin/datahub/Ingestion.java
@@ -94,7 +94,8 @@ public class Ingestion extends Task implements RunnableTask<ScriptOutput>, Names
     private String containerImage = DEFAULT_IMAGE;
 
     @Schema(
-        title = "The environments for Ingestion DataHub"
+        title = "Environment variables",
+        description = "Environment variables to set in the ingestion container."
     )
     @PluginProperty(dynamic = true, group = "execution")
     private Map<String, String> env;
@@ -108,7 +109,9 @@ public class Ingestion extends Task implements RunnableTask<ScriptOutput>, Names
     private TaskRunner<?> taskRunner = Docker.instance();
 
     @Schema(
-        title = "The Ingestion DataHub Recipe"
+        title = "The DataHub ingestion recipe",
+        description = "The DataHub ingestion recipe. Provide it either inline as a map holding the full recipe YAML " +
+            "structure (`source`, `sink`, etc.), or as a `kestra://` internal-storage URI pointing to a recipe file. Required."
     )
     @NotNull
     @PluginProperty(group = "main")


### PR DESCRIPTION
## Summary

Documentation correctness + completeness review of **plugin-datahub** (task-level `@Schema`/`@Example` annotations, `package-info.java`, `metadata/index.yaml`, and the how-to doc). Docs-only pass — no behavior, defaults, `@NotNull`, or `group` changes. 1 task: `Ingestion` (`DataHubLogConsumer` is an internal log helper, not a doc surface).

### Doc fixes in this PR

- **`recipe` had a title but no description.** It is the central, required property, and its two accepted forms (inline map vs. `kestra://` URI) were only documented in the how-to/metadata, not on the annotation. Added a description matching the existing docs.
- **`env` title was misleading** — "The environments for Ingestion DataHub" reads as deployment environments, but the field is a `Map<String,String>` of environment variables. Retitled to "Environment variables" with a description.

Everything else was accurate and left unchanged: the `Ingestion` title/description, `containerImage`/`taskRunner` defaults (`acryldata/datahub-ingestion:head`, Docker), the inline-recipe example, `package-info` subgroup title/description, `index.yaml`, and the how-to (authentication-via-recipe, `datahub ingest -c recipe.yml`, namespaceFiles/inputFiles/outputFiles).

## Engineering flag list (NOT addressed here — code-level, out of scope for a docs pass)

These are the reason I flagged rather than rewrote example 2. Both are verifiable from `Ingestion.getRecipe()` in this repo, but the end-to-end effect depends on core `CommandsWrapper`/render internals that are not in this repo, so please verify:

- **The documented `kestra://` URI / recipe-file mode appears unreachable from YAML.** `getRecipe` only branches on `this.recipe instanceof URI` (a `java.net.URI`). A YAML value like `recipe: "kestra://..."` deserializes to a `String`, not a `URI`, so it hits the `else` branch and does `(Map<String, Object>) recipe` → **ClassCastException**. The `instanceof URI` branch looks like it can never be taken for a YAML-authored flow.
- **`recipe` is not rendered.** It is `@PluginProperty(group = "main")` **without** `dynamic = true`, and `getRecipe` never calls `runContext.render(this.recipe)`. So Pebble expressions passed *as* `recipe` (e.g. example 2's `recipe: "{{ input('recipe_file') }}"`) — and, potentially, secret/templated values embedded *inside* an inline recipe map (e.g. example 1's `password: "{{ secret('MYSQL_PASSWORD') }}"`) — may be written to `recipe.yml` literally rather than resolved. **Example 2 should be verified end to end**; if the URI mode is intended to work, `recipe` likely needs `dynamic = true` and/or explicit URI-string handling + rendering.
- `AGENTS.md` is stale/templated boilerplate (generic "What/Why/How") — not a doc surface, noting for cleanup.
